### PR TITLE
fix: ignore games without a scheduled date

### DIFF
--- a/app/data/normalization/games.ts
+++ b/app/data/normalization/games.ts
@@ -116,5 +116,5 @@ type NormalizeGames = (
 ) => Game[];
 export const normalizeGames: NormalizeGames = (apiGames, bootstrapResponse) =>
   apiGames
-    .filter((game) => game.VisitorCode !== "TBD" && game.HomeCode !== "TBD")
+    .filter((game) => game.VisitorCode !== "TBD" && game.HomeCode !== "TBD" && game.GameDateISO8601 !== "")
     .map((game) => normalizeGame(game, bootstrapResponse));


### PR DESCRIPTION
Hello :)

I noticed that the homepage is currently failing with this error:

```text
Error: Invalid ISO 8601 date time string: 
    at rf (https://pwhl-remix.vercel.app/assets/useDays-DiTIx-41.js:1:65442)
    at nf (https://pwhl-remix.vercel.app/assets/useDays-DiTIx-41.js:1:65806)
    at https://pwhl-remix.vercel.app/assets/useDays-DiTIx-41.js:1:212451
    at Array.filter (<anonymous>)
    at X3 (https://pwhl-remix.vercel.app/assets/useDays-DiTIx-41.js:1:212437)
    at Fu (https://pwhl-remix.vercel.app/assets/components-DGPsvh-o.js:38:19518)
    at Ia (https://pwhl-remix.vercel.app/assets/components-DGPsvh-o.js:40:3139)
    at gh (https://pwhl-remix.vercel.app/assets/components-DGPsvh-o.js:40:44705)
    at mh (https://pwhl-remix.vercel.app/assets/components-DGPsvh-o.js:40:39703)
    at $v (https://pwhl-remix.vercel.app/assets/components-DGPsvh-o.js:40:39631)
```

Seems it's happening because there as some games without a date (not yet scheduled), for example:

```json
{
            "type": "Playoff",
            "id": 205,
            "gameState": "Scheduled",
            "homeTeam": {
                "id": 6,
                "name": "Sceptres",
                "logoUrl": "https://assets.leaguestat.com/pwhl/logos/50x50/6_6.png",
                "wins": 1,
                "losses": 0,
                "otLosses": 0,
                "record": "1-0-0"
            },
            "visitingTeam": {
                "id": 2,
                "name": "Frost",
                "logoUrl": "https://assets.leaguestat.com/pwhl/logos/50x50/2_6.png",
                "wins": 0,
                "losses": 1,
                "otLosses": 0,
                "record": "0-1-0"
            },
            "gameDate": ""
        }
```

This PR includes a small fix to ignore games without a date on the homepage.